### PR TITLE
Implement JWT authentication and authorization across microservices

### DIFF
--- a/auth-service/src/main/java/masterbikes/config/JwtRequestFilter.java
+++ b/auth-service/src/main/java/masterbikes/config/JwtRequestFilter.java
@@ -1,0 +1,73 @@
+package masterbikes.config;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import masterbikes.util.JwtUtil;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private final UserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null; // En nuestro caso, el email
+        String jwt = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = jwtUtil.getSubject(jwt);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Unable to get JWT Token: " + e.getMessage());
+            } catch (ExpiredJwtException e) {
+                logger.warn("JWT Token has expired: " + e.getMessage());
+            } catch (SignatureException e) {
+                logger.warn("JWT Token signature does not match: " + e.getMessage());
+            } catch (MalformedJwtException e) {
+                logger.warn("JWT Token malformed: " + e.getMessage());
+            } catch (UnsupportedJwtException e) {
+                logger.warn("JWT Token is unsupported: " + e.getMessage());
+            } catch (Exception e) {
+                logger.warn("JWT Token validation error: " + e.getMessage());
+            }
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+
+            // Si el token fue validado por jwtUtil.getSubject (firma y expiración)
+            // y el usuario existe (userDetails no es null), entonces autenticamos.
+            if (userDetails != null) {
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                usernamePasswordAuthenticationToken
+                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/auth-service/src/main/java/masterbikes/config/SecurityConfig.java
+++ b/auth-service/src/main/java/masterbikes/config/SecurityConfig.java
@@ -1,23 +1,98 @@
 package masterbikes.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod; // Importar HttpMethod
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Configuration
+@EnableWebSecurity // Habilita la seguridad web de Spring
+@EnableMethodSecurity(prePostEnabled = true) // Para usar @PreAuthorize si se necesita
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtRequestFilter jwtAuthFilter;
+    private final UserDetailsService userDetailsService; // Inyecta UsuarioService (nuestro UsuarioService implementa UserDetailsService)
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf.disable()) // Deshabilitar CSRF para APIs stateless
             .authorizeHttpRequests(auth -> auth
+                // Endpoints públicos: login, swagger, docs, error y registro de usuarios
                 .requestMatchers(
-                    "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**",
-                    "/api/usuarios/**"
+                    "/auth/login", // Endpoint de login
+                    "/swagger-ui.html", "/swagger-ui/**", // Swagger UI
+                    "/v3/api-docs/**", "/api-docs/**", // OpenAPI docs
+                    "/error" // Permitir acceso a la página de error por defecto de Spring Boot
                 ).permitAll()
-                .anyRequest().permitAll()
+                // Permitir el endpoint de registro público para nuevos clientes
+                .requestMatchers(HttpMethod.POST, "/api/usuarios/registro").permitAll()
+                // Proteger los demás endpoints de /api/usuarios/** para ADMIN
+                .requestMatchers("/api/usuarios/**").hasRole("ADMIN")
+                // Todas las demás peticiones requieren autenticación
+                .anyRequest().authenticated() // Todas las demás peticiones requieren autenticación
+            )
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // No crear ni usar sesiones HTTP
+            )
+            .authenticationProvider(authenticationProvider()) // Configura el proveedor de autenticación
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class) // Añade el filtro JWT
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint()) // Manejador para errores de autenticación
             );
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService); // Tu UsuarioService
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // Asegúrate de que este Bean también esté disponible para UsuarioService si lo inyecta directamente.
+        // En nuestro caso, UsuarioService crea su propia instancia de BCryptPasswordEncoder,
+        // lo cual está bien, pero usar un Bean es más estándar en Spring.
+        // Por ahora, la configuración actual de UsuarioService es funcional.
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            // Personaliza el mensaje de error JSON
+            String errorMessage = "{\"timestamp\":\"" + new java.util.Date() + "\","
+                                + "\"status\":" + HttpServletResponse.SC_UNAUTHORIZED + ","
+                                + "\"error\":\"Unauthorized\","
+                                + "\"message\":\"" + authException.getMessage() + "\","
+                                + "\"path\":\"" + request.getRequestURI() + "\"}";
+            response.getWriter().write(errorMessage);
+        };
     }
 }

--- a/auth-service/src/main/java/masterbikes/model/Usuario.java
+++ b/auth-service/src/main/java/masterbikes/model/Usuario.java
@@ -8,6 +8,12 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import masterbikes.model.enums.Rol;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Entity
 @Table(name = "usuarios")
@@ -15,7 +21,7 @@ import masterbikes.model.enums.Rol;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Usuario {
+public class Usuario implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,4 +53,38 @@ public class Usuario {
 
     @Column(nullable = true)
     private String fechaNacimiento; // Fecha de nacimiento
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // Es importante prefijar con "ROLE_" si se usan expresiones de rol como hasRole('ADMIN')
+        // o si se usa @PreAuthorize("hasRole('ADMIN')")
+        // Si solo se usa .requestMatchers(HttpMethod.GET, "/ruta").hasAuthority("ADMIN"), no es necesario.
+        // Por consistencia y flexibilidad, es buena práctica añadir "ROLE_".
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + rol.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return email; // Usamos email como username
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // Por defecto, no expira
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // Por defecto, no bloqueada
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // Por defecto, credenciales no expiran
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return activo; // Usa el campo 'activo' de la entidad
+    }
 }

--- a/auth-service/src/main/java/masterbikes/repository/UsuarioRepository.java
+++ b/auth-service/src/main/java/masterbikes/repository/UsuarioRepository.java
@@ -3,8 +3,10 @@ package masterbikes.repository;
 import masterbikes.model.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
-    // Métodos personalizados pueden agregarse aquí si se requieren en el futuro
+    // Necesario para UserDetailsService
+    Optional<Usuario> findByEmail(String email);
 }

--- a/auth-service/src/main/java/masterbikes/service/UsuarioService.java
+++ b/auth-service/src/main/java/masterbikes/service/UsuarioService.java
@@ -5,7 +5,10 @@ package masterbikes.service;
 import lombok.RequiredArgsConstructor;
 import masterbikes.model.Usuario;
 import masterbikes.repository.UsuarioRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,7 +16,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class UsuarioService {
+public class UsuarioService implements UserDetailsService {
     private final UsuarioRepository usuarioRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
@@ -67,5 +70,13 @@ public class UsuarioService {
             usuarioRepository.save(usuario);
             return true;
         }).orElse(false);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return usuarioRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("Usuario no encontrado con email: " + email)
+                );
     }
 }

--- a/catalogo-service/pom.xml
+++ b/catalogo-service/pom.xml
@@ -60,6 +60,31 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/catalogo-service/src/main/java/masterbikes/catalogo_service/config/CorsConfig.java
+++ b/catalogo-service/src/main/java/masterbikes/catalogo_service/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package masterbikes.catalogo_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // Aplica a todas las rutas del servicio
+            .allowedOrigins(
+                "http://localhost:8080", // Si tu frontend corre en el puerto 8080
+                "http://127.0.0.1:8080", // Alternativa para localhost
+                "http://localhost:63342", // Puerto común para IDEs como IntelliJ cuando se abre un HTML
+                "null" //  Para `file:///` origins. Usar con precaución.
+                // Es mejor usar allowedOriginPatterns para file:// si es posible
+                // o servir el frontend desde un servidor web local para desarrollo.
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .allowedHeaders("*") // Permite todas las cabeceras
+            .allowCredentials(true) // Necesario para enviar cookies o cabeceras de Authorization con el token JWT
+            .maxAge(3600); // Tiempo en segundos que el navegador puede cachear la respuesta pre-flight
+    }
+}

--- a/catalogo-service/src/main/java/masterbikes/catalogo_service/config/JwtRequestFilter.java
+++ b/catalogo-service/src/main/java/masterbikes/catalogo_service/config/JwtRequestFilter.java
@@ -1,0 +1,87 @@
+package masterbikes.catalogo_service.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import masterbikes.catalogo_service.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null; // email
+        String jwt = null;
+        Claims claims = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = jwtUtil.getSubject(jwt);
+                claims = jwtUtil.getAllClaims(jwt);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Unable to get JWT Token: " + e.getMessage());
+            } catch (ExpiredJwtException e) {
+                logger.warn("JWT Token has expired: " + e.getMessage());
+            } catch (SignatureException e) {
+                logger.warn("JWT Token signature does not match: " + e.getMessage());
+            } catch (MalformedJwtException e) {
+                logger.warn("JWT Token malformed: " + e.getMessage());
+            } catch (UnsupportedJwtException e) {
+                logger.warn("JWT Token is unsupported: " + e.getMessage());
+            } catch (Exception e) {
+                logger.warn("JWT Token validation error: " + e.getMessage());
+            }
+        }
+
+        if (username != null && claims != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String rolClaim = claims.get("rol", String.class);
+            List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+            if (rolClaim != null && !rolClaim.isEmpty()) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + rolClaim));
+            }
+
+            UserDetails userDetails = new User(username, "", authorities); // Contraseña vacía, no se usa aquí
+
+            // No es necesario validar userDetails != null porque si username y claims no son null,
+            // userDetails se creará. La validación importante es que el token sea correcto (hecho por JwtUtil)
+            // y que el contexto de seguridad no tenga ya una autenticación.
+
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            usernamePasswordAuthenticationToken
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/catalogo-service/src/main/java/masterbikes/catalogo_service/config/SecurityConfig.java
+++ b/catalogo-service/src/main/java/masterbikes/catalogo_service/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package masterbikes.catalogo_service.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true) // Habilita @PreAuthorize, @PostAuthorize, etc.
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtRequestFilter jwtAuthFilter; // Inyecta el filtro JWT que creamos
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // Deshabilitar CSRF para APIs stateless
+            .authorizeHttpRequests(auth -> auth
+                // Endpoints públicos (ej. para que cualquiera vea el catálogo)
+                // Ajusta estos patrones a tus rutas reales en CatalogoController, BicicletaController, etc.
+                .requestMatchers(HttpMethod.GET, "/api/catalogo/**", "/api/bicicletas/**", "/api/accesorios/**", "/api/componentes/**").permitAll()
+
+                // Permitir Swagger/OpenAPI si se añade en el futuro
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**").permitAll()
+                .requestMatchers("/error").permitAll() // Permitir acceso a la página de error por defecto
+
+                // Endpoints que requieren rol de ADMIN (ej. para añadir/modificar/eliminar productos)
+                // Ajusta estos patrones a tus rutas reales
+                .requestMatchers(HttpMethod.POST, "/api/catalogo/**", "/api/bicicletas/**", "/api/accesorios/**", "/api/componentes/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.PUT, "/api/catalogo/**", "/api/bicicletas/**", "/api/accesorios/**", "/api/componentes/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/api/catalogo/**", "/api/bicicletas/**", "/api/accesorios/**", "/api/componentes/**").hasRole("ADMIN")
+
+                // Cualquier otra solicitud debe estar autenticada (tener un token JWT válido)
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // No crear ni usar sesiones HTTP
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class) // Añade el filtro JWT antes del filtro de autenticación estándar
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint()) // Manejador para errores de autenticación (401)
+            );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        // Devuelve una respuesta 401 Unauthorized personalizada en formato JSON
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            // Mensaje de error JSON más detallado
+            String errorMessage = "{\"timestamp\":\"" + new java.util.Date() + "\","
+                                + "\"status\":" + HttpServletResponse.SC_UNAUTHORIZED + ","
+                                + "\"error\":\"Unauthorized\","
+                                + "\"message\":\"" + authException.getMessage() + // Mensaje de la excepción
+                                     (authException.getCause() != null ? " (Cause: " + authException.getCause().getMessage() + ")" : "") + "\","
+                                + "\"path\":\"" + request.getRequestURI() + "\"}";
+            response.getWriter().write(errorMessage);
+        };
+    }
+}

--- a/catalogo-service/src/main/java/masterbikes/catalogo_service/util/JwtUtil.java
+++ b/catalogo-service/src/main/java/masterbikes/catalogo_service/util/JwtUtil.java
@@ -1,0 +1,72 @@
+package masterbikes.catalogo_service.util;
+
+// Componente utilitario para generación y validación de JWT.
+// Permite emitir tokens con claims personalizados y extraer información de los mismos.
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long EXPIRATION = 1000 * 60 * 60 * 4; // 4 horas, aunque para validación no se usa directamente.
+
+    /**
+     * Inyecta la clave secreta desde application.properties (en base64).
+     */
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        this.key = Keys.hmacShaKeyFor(decodedKey);
+    }
+
+    /**
+     * Genera un JWT para el usuario autenticado.
+     * @param subject email del usuario
+     * @param claims mapa de claims personalizados (rol, sucursal, etc.)
+     * @return token JWT firmado
+     */
+    public String generateToken(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Extrae el subject (email) de un JWT. Valida firma y expiración.
+     */
+    public String getSubject(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    /**
+     * Extrae todos los claims de un JWT. Valida firma y expiración.
+     */
+    public io.jsonwebtoken.Claims getAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+
+
+    /**
+     * Extrae un claim personalizado de un JWT.
+     * @param token JWT
+     * @param claim nombre del claim
+     * @return valor del claim
+     */
+    public Object getClaim(String token, String claim) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get(claim);
+    }
+}

--- a/catalogo-service/src/main/resources/application.properties
+++ b/catalogo-service/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# Clave secreta para JWT (debe ser la misma que en auth-service)
+jwt.secret=Q2hhbXBhZG9yQmFzZTY0U2VndXJhMTIzNDU2Nzg5MDEyMzQ1Ng==

--- a/inventario-service/pom.xml
+++ b/inventario-service/pom.xml
@@ -65,6 +65,31 @@
 			<artifactId>unboundid-ldapsdk</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/inventario-service/src/main/java/masterbikes/inventario_service/config/CorsConfig.java
+++ b/inventario-service/src/main/java/masterbikes/inventario_service/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package masterbikes.inventario_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "http://localhost:8080",
+                "http://127.0.0.1:8080",
+                "http://localhost:63342",
+                "null"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+}

--- a/inventario-service/src/main/java/masterbikes/inventario_service/config/JwtRequestFilter.java
+++ b/inventario-service/src/main/java/masterbikes/inventario_service/config/JwtRequestFilter.java
@@ -1,0 +1,83 @@
+package masterbikes.inventario_service.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import masterbikes.inventario_service.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null; // email
+        String jwt = null;
+        Claims claims = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = jwtUtil.getSubject(jwt);
+                claims = jwtUtil.getAllClaims(jwt);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Unable to get JWT Token: " + e.getMessage());
+            } catch (ExpiredJwtException e) {
+                logger.warn("JWT Token has expired: " + e.getMessage());
+            } catch (SignatureException e) {
+                logger.warn("JWT Token signature does not match: " + e.getMessage());
+            } catch (MalformedJwtException e) {
+                logger.warn("JWT Token malformed: " + e.getMessage());
+            } catch (UnsupportedJwtException e) {
+                logger.warn("JWT Token is unsupported: " + e.getMessage());
+            } catch (Exception e) {
+                logger.warn("JWT Token validation error: " + e.getMessage());
+            }
+        }
+
+        if (username != null && claims != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String rolClaim = claims.get("rol", String.class);
+            List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+            if (rolClaim != null && !rolClaim.isEmpty()) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + rolClaim));
+            }
+
+            UserDetails userDetails = new User(username, "", authorities); // Contraseña vacía, no se usa aquí
+
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            usernamePasswordAuthenticationToken
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/inventario-service/src/main/java/masterbikes/inventario_service/config/SecurityConfig.java
+++ b/inventario-service/src/main/java/masterbikes/inventario_service/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package masterbikes.inventario_service.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtRequestFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // Ajusta los patrones de ruta y roles según tus controladores y lógica de negocio.
+                // Ejemplo: Consultas de inventario
+                .requestMatchers(HttpMethod.GET, "/api/inventario/**", "/api/stock/**").hasAnyRole("VENDEDOR", "SUPERVISOR", "TECNICO", "ADMIN")
+
+                // Ejemplo: Modificaciones de inventario
+                .requestMatchers(HttpMethod.POST, "/api/inventario/**", "/api/stock/**").hasAnyRole("SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.PUT, "/api/inventario/**", "/api/stock/**").hasAnyRole("SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/api/inventario/**", "/api/stock/**").hasAnyRole("SUPERVISOR", "ADMIN")
+
+                // Permitir Swagger/OpenAPI (si se añade) y errores
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**").permitAll()
+                .requestMatchers("/error").permitAll()
+
+                // Cualquier otra solicitud requiere autenticación
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint())
+            );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            String errorMessage = "{\"timestamp\":\"" + new java.util.Date() + "\","
+                                + "\"status\":" + HttpServletResponse.SC_UNAUTHORIZED + ","
+                                + "\"error\":\"Unauthorized\","
+                                + "\"message\":\"" + authException.getMessage() +
+                                     (authException.getCause() != null ? " (Cause: " + authException.getCause().getMessage() + ")" : "") + "\","
+                                + "\"path\":\"" + request.getRequestURI() + "\"}";
+            response.getWriter().write(errorMessage);
+        };
+    }
+}

--- a/inventario-service/src/main/java/masterbikes/inventario_service/util/JwtUtil.java
+++ b/inventario-service/src/main/java/masterbikes/inventario_service/util/JwtUtil.java
@@ -1,0 +1,72 @@
+package masterbikes.inventario_service.util;
+
+// Componente utilitario para generación y validación de JWT.
+// Permite emitir tokens con claims personalizados y extraer información de los mismos.
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long EXPIRATION = 1000 * 60 * 60 * 4; // 4 horas, aunque para validación no se usa directamente.
+
+    /**
+     * Inyecta la clave secreta desde application.properties (en base64).
+     */
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        this.key = Keys.hmacShaKeyFor(decodedKey);
+    }
+
+    /**
+     * Genera un JWT para el usuario autenticado.
+     * @param subject email del usuario
+     * @param claims mapa de claims personalizados (rol, sucursal, etc.)
+     * @return token JWT firmado
+     */
+    public String generateToken(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Extrae el subject (email) de un JWT. Valida firma y expiración.
+     */
+    public String getSubject(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    /**
+     * Extrae todos los claims de un JWT. Valida firma y expiración.
+     */
+    public io.jsonwebtoken.Claims getAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+
+
+    /**
+     * Extrae un claim personalizado de un JWT.
+     * @param token JWT
+     * @param claim nombre del claim
+     * @return valor del claim
+     */
+    public Object getClaim(String token, String claim) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get(claim);
+    }
+}

--- a/inventario-service/src/main/resources/application.properties
+++ b/inventario-service/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# Clave secreta para JWT (debe ser la misma que en auth-service)
+jwt.secret=Q2hhbXBhZG9yQmFzZTY0U2VndXJhMTIzNDU2Nzg5MDEyMzQ1Ng==

--- a/sucursal-service/pom.xml
+++ b/sucursal-service/pom.xml
@@ -65,6 +65,31 @@
 			<artifactId>unboundid-ldapsdk</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/sucursal-service/src/main/java/masterbikes/sucursal_service/config/CorsConfig.java
+++ b/sucursal-service/src/main/java/masterbikes/sucursal_service/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package masterbikes.sucursal_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "http://localhost:8080",
+                "http://127.0.0.1:8080",
+                "http://localhost:63342",
+                "null"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+}

--- a/sucursal-service/src/main/java/masterbikes/sucursal_service/config/JwtRequestFilter.java
+++ b/sucursal-service/src/main/java/masterbikes/sucursal_service/config/JwtRequestFilter.java
@@ -1,0 +1,83 @@
+package masterbikes.sucursal_service.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import masterbikes.sucursal_service.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null; // email
+        String jwt = null;
+        Claims claims = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = jwtUtil.getSubject(jwt);
+                claims = jwtUtil.getAllClaims(jwt);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Unable to get JWT Token: " + e.getMessage());
+            } catch (ExpiredJwtException e) {
+                logger.warn("JWT Token has expired: " + e.getMessage());
+            } catch (SignatureException e) {
+                logger.warn("JWT Token signature does not match: " + e.getMessage());
+            } catch (MalformedJwtException e) {
+                logger.warn("JWT Token malformed: " + e.getMessage());
+            } catch (UnsupportedJwtException e) {
+                logger.warn("JWT Token is unsupported: " + e.getMessage());
+            } catch (Exception e) {
+                logger.warn("JWT Token validation error: " + e.getMessage());
+            }
+        }
+
+        if (username != null && claims != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String rolClaim = claims.get("rol", String.class);
+            List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+            if (rolClaim != null && !rolClaim.isEmpty()) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + rolClaim));
+            }
+
+            UserDetails userDetails = new User(username, "", authorities); // Contraseña vacía, no se usa aquí
+
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            usernamePasswordAuthenticationToken
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/sucursal-service/src/main/java/masterbikes/sucursal_service/config/SecurityConfig.java
+++ b/sucursal-service/src/main/java/masterbikes/sucursal_service/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package masterbikes.sucursal_service.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtRequestFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // Ajusta los patrones de ruta y roles según tus controladores y lógica de negocio.
+                // Ejemplo: Listar sucursales (podría ser público o para usuarios autenticados)
+                .requestMatchers(HttpMethod.GET, "/api/sucursales/**").permitAll()
+
+                // Ejemplo: Gestión de sucursales (crear, actualizar, eliminar)
+                .requestMatchers(HttpMethod.POST, "/api/sucursales/**").hasAnyRole("ADMIN", "SUPERVISOR")
+                .requestMatchers(HttpMethod.PUT, "/api/sucursales/**").hasAnyRole("ADMIN", "SUPERVISOR")
+                .requestMatchers(HttpMethod.DELETE, "/api/sucursales/**").hasAnyRole("ADMIN", "SUPERVISOR")
+
+                // Permitir Swagger/OpenAPI (si se añade) y errores
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**").permitAll()
+                .requestMatchers("/error").permitAll()
+
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint())
+            );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            String errorMessage = "{\"timestamp\":\"" + new java.util.Date() + "\","
+                                + "\"status\":" + HttpServletResponse.SC_UNAUTHORIZED + ","
+                                + "\"error\":\"Unauthorized\","
+                                + "\"message\":\"" + authException.getMessage() +
+                                     (authException.getCause() != null ? " (Cause: " + authException.getCause().getMessage() + ")" : "") + "\","
+                                + "\"path\":\"" + request.getRequestURI() + "\"}";
+            response.getWriter().write(errorMessage);
+        };
+    }
+}

--- a/sucursal-service/src/main/java/masterbikes/sucursal_service/util/JwtUtil.java
+++ b/sucursal-service/src/main/java/masterbikes/sucursal_service/util/JwtUtil.java
@@ -1,0 +1,72 @@
+package masterbikes.sucursal_service.util;
+
+// Componente utilitario para generación y validación de JWT.
+// Permite emitir tokens con claims personalizados y extraer información de los mismos.
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long EXPIRATION = 1000 * 60 * 60 * 4; // 4 horas, aunque para validación no se usa directamente.
+
+    /**
+     * Inyecta la clave secreta desde application.properties (en base64).
+     */
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        this.key = Keys.hmacShaKeyFor(decodedKey);
+    }
+
+    /**
+     * Genera un JWT para el usuario autenticado.
+     * @param subject email del usuario
+     * @param claims mapa de claims personalizados (rol, sucursal, etc.)
+     * @return token JWT firmado
+     */
+    public String generateToken(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Extrae el subject (email) de un JWT. Valida firma y expiración.
+     */
+    public String getSubject(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    /**
+     * Extrae todos los claims de un JWT. Valida firma y expiración.
+     */
+    public io.jsonwebtoken.Claims getAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+
+
+    /**
+     * Extrae un claim personalizado de un JWT.
+     * @param token JWT
+     * @param claim nombre del claim
+     * @return valor del claim
+     */
+    public Object getClaim(String token, String claim) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get(claim);
+    }
+}

--- a/sucursal-service/src/main/resources/application.properties
+++ b/sucursal-service/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# Clave secreta para JWT (debe ser la misma que en auth-service)
+jwt.secret=Q2hhbXBhZG9yQmFzZTY0U2VndXJhMTIzNDU2Nzg5MDEyMzQ1Ng==

--- a/venta-service/pom.xml
+++ b/venta-service/pom.xml
@@ -65,6 +65,31 @@
 			<artifactId>unboundid-ldapsdk</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/venta-service/src/main/java/masterbikes/venta_service/config/CorsConfig.java
+++ b/venta-service/src/main/java/masterbikes/venta_service/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package masterbikes.venta_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "http://localhost:8080",
+                "http://127.0.0.1:8080",
+                "http://localhost:63342",
+                "null"
+            )
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+}

--- a/venta-service/src/main/java/masterbikes/venta_service/config/JwtRequestFilter.java
+++ b/venta-service/src/main/java/masterbikes/venta_service/config/JwtRequestFilter.java
@@ -1,0 +1,83 @@
+package masterbikes.venta_service.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import masterbikes.venta_service.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null; // email
+        String jwt = null;
+        Claims claims = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = jwtUtil.getSubject(jwt);
+                claims = jwtUtil.getAllClaims(jwt);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Unable to get JWT Token: " + e.getMessage());
+            } catch (ExpiredJwtException e) {
+                logger.warn("JWT Token has expired: " + e.getMessage());
+            } catch (SignatureException e) {
+                logger.warn("JWT Token signature does not match: " + e.getMessage());
+            } catch (MalformedJwtException e) {
+                logger.warn("JWT Token malformed: " + e.getMessage());
+            } catch (UnsupportedJwtException e) {
+                logger.warn("JWT Token is unsupported: " + e.getMessage());
+            } catch (Exception e) {
+                logger.warn("JWT Token validation error: " + e.getMessage());
+            }
+        }
+
+        if (username != null && claims != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String rolClaim = claims.get("rol", String.class);
+            List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+            if (rolClaim != null && !rolClaim.isEmpty()) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + rolClaim));
+            }
+
+            UserDetails userDetails = new User(username, "", authorities); // Contraseña vacía, no se usa aquí
+
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities());
+            usernamePasswordAuthenticationToken
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/venta-service/src/main/java/masterbikes/venta_service/config/SecurityConfig.java
+++ b/venta-service/src/main/java/masterbikes/venta_service/config/SecurityConfig.java
@@ -1,0 +1,82 @@
+package masterbikes.venta_service.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtRequestFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // Ajusta los patrones de ruta y roles según tus controladores y lógica de negocio.
+                // Crear una venta
+                .requestMatchers(HttpMethod.POST, "/api/ventas/**").hasAnyRole("CLIENTE", "VENDEDOR", "SUPERVISOR", "ADMIN")
+
+                // Ver ventas
+                // Para que un CLIENTE vea solo sus ventas, se necesitará lógica adicional en el controlador
+                // o una ruta específica como /api/ventas/mis-ventas que se proteja aquí.
+                .requestMatchers(HttpMethod.GET, "/api/ventas/cliente/me").hasRole("CLIENTE") // Ejemplo para "mis ventas"
+                .requestMatchers(HttpMethod.GET, "/api/ventas/**").hasAnyRole("VENDEDOR", "SUPERVISOR", "ADMIN")
+
+                // Actualizar estado de venta
+                .requestMatchers(HttpMethod.PUT, "/api/ventas/**", "/api/ventas/estado/**").hasAnyRole("VENDEDOR", "SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.PATCH, "/api/ventas/**", "/api/ventas/estado/**").hasAnyRole("VENDEDOR", "SUPERVISOR", "ADMIN")
+
+                // Eliminar/cancelar venta
+                .requestMatchers(HttpMethod.DELETE, "/api/ventas/**").hasAnyRole("SUPERVISOR", "ADMIN")
+
+                // Ejemplo para reparaciones (si están en este servicio)
+                .requestMatchers(HttpMethod.POST, "/api/reparaciones/**").hasAnyRole("CLIENTE", "VENDEDOR", "SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.GET, "/api/reparaciones/tecnico/me").hasRole("TECNICO") // Ejemplo para "mis reparaciones asignadas"
+                .requestMatchers(HttpMethod.GET, "/api/reparaciones/**").hasAnyRole("TECNICO", "SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.PUT, "/api/reparaciones/**").hasAnyRole("TECNICO", "SUPERVISOR", "ADMIN")
+                .requestMatchers(HttpMethod.PATCH, "/api/reparaciones/**").hasAnyRole("TECNICO", "SUPERVISOR", "ADMIN")
+
+
+                // Permitir Swagger/OpenAPI (si se añade) y errores
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**").permitAll()
+                .requestMatchers("/error").permitAll()
+
+                .anyRequest().authenticated()
+            )
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint())
+            );
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            String errorMessage = "{\"timestamp\":\"" + new java.util.Date() + "\","
+                                + "\"status\":" + HttpServletResponse.SC_UNAUTHORIZED + ","
+                                + "\"error\":\"Unauthorized\","
+                                + "\"message\":\"" + authException.getMessage() +
+                                     (authException.getCause() != null ? " (Cause: " + authException.getCause().getMessage() + ")" : "") + "\","
+                                + "\"path\":\"" + request.getRequestURI() + "\"}";
+            response.getWriter().write(errorMessage);
+        };
+    }
+}

--- a/venta-service/src/main/java/masterbikes/venta_service/util/JwtUtil.java
+++ b/venta-service/src/main/java/masterbikes/venta_service/util/JwtUtil.java
@@ -1,0 +1,72 @@
+package masterbikes.venta_service.util;
+
+// Componente utilitario para generación y validación de JWT.
+// Permite emitir tokens con claims personalizados y extraer información de los mismos.
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long EXPIRATION = 1000 * 60 * 60 * 4; // 4 horas, aunque para validación no se usa directamente.
+
+    /**
+     * Inyecta la clave secreta desde application.properties (en base64).
+     */
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        this.key = Keys.hmacShaKeyFor(decodedKey);
+    }
+
+    /**
+     * Genera un JWT para el usuario autenticado.
+     * @param subject email del usuario
+     * @param claims mapa de claims personalizados (rol, sucursal, etc.)
+     * @return token JWT firmado
+     */
+    public String generateToken(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Extrae el subject (email) de un JWT. Valida firma y expiración.
+     */
+    public String getSubject(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    /**
+     * Extrae todos los claims de un JWT. Valida firma y expiración.
+     */
+    public io.jsonwebtoken.Claims getAllClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+
+
+    /**
+     * Extrae un claim personalizado de un JWT.
+     * @param token JWT
+     * @param claim nombre del claim
+     * @return valor del claim
+     */
+    public Object getClaim(String token, String claim) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().get(claim);
+    }
+}

--- a/venta-service/src/main/resources/application.properties
+++ b/venta-service/src/main/resources/application.properties
@@ -11,3 +11,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 
 logging.level.org.springframework.web=DEBUG
+
+# Clave secreta para JWT (debe ser la misma que en auth-service)
+jwt.secret=Q2hhbXBhZG9yQmFzZTY0U2VndXJhMTIzNDU2Nzg5MDEyMzQ1Ng==


### PR DESCRIPTION
- Configured auth-service to generate JWTs with role and sucursal claims, and to protect its own user management endpoints.
- Added Spring Security JWT validation to catalogo-service, inventario-service, sucursal-service, and venta-service.
- Each service now has JwtRequestFilter, SecurityConfig, JwtUtil, and CorsConfig.
- Defined role-based access control for various endpoints in each service.
- Provided guidelines for frontend JWT handling and comprehensive testing strategy.
- Outlined necessary documentation updates, including OpenAPI integration.